### PR TITLE
Don't raise error when tracing has not started

### DIFF
--- a/lib/aws/xray/context.rb
+++ b/lib/aws/xray/context.rb
@@ -18,6 +18,11 @@ module Aws
           Thread.current.thread_variable_get(VAR_NAME) || raise(NotSetError)
         end
 
+        # @return [Boolean]
+        def started?
+          !!Thread.current.thread_variable_get(VAR_NAME)
+        end
+
         # @param [String] name logical name of this tracing context.
         # @param [Aws::Xray::Client] client Require this parameter because the
         #   socket inside client can live longer than this context. For example

--- a/lib/aws/xray/faraday.rb
+++ b/lib/aws/xray/faraday.rb
@@ -11,6 +11,8 @@ module Aws
       end
 
       def call(req_env)
+        return @app.call(req_env) unless Context.started?
+
         name = @name || req_env.request_headers['Host'] || "unknown-request-from-#{Context.current.name}"
 
         Context.current.child_trace(remote: true, name: name) do |sub|

--- a/spec/faraday_spec.rb
+++ b/spec/faraday_spec.rb
@@ -191,4 +191,12 @@ RSpec.describe Aws::Xray::Faraday do
       expect(e['stack'].first['path']).to end_with('.rb')
     end
   end
+
+  context 'when tracing has not been started' do
+    it 'does not raise any errors' do
+      response = nil
+      expect { response = client.get('/foo') }.not_to raise_error
+      expect(response.status).to eq(200)
+    end
+  end
 end


### PR DESCRIPTION
Only in Faraday middleware.

To avoid facing unexpected errors in separated environments from a web app environment. e.g. a batch environment.