### PR TITLE
Do not fail in development and test env

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ end
 
 ## Configurations
 ### X-Ray agent location
+aws-xray does not send any trace data default. Set `AWS_XRAY_LOCATION` environment variable like `AWS_XRAY_LOCATION=localhost:2000`
+or set proper aws-agent location with configuration interface like `Aws::Xray.config.client_options = { host: "localhost", port: 2000 }`.
+
 In container environments, we often run xray agent container beside application container.
 For that case, pass `AWS_XRAY_LOCATION` environment variable to container to specify host and port of xray agent.
 

--- a/lib/aws/xray.rb
+++ b/lib/aws/xray.rb
@@ -2,7 +2,7 @@ require 'aws/xray/version'
 require 'aws/xray/rack'
 require 'aws/xray/faraday'
 require 'aws/xray/configuration'
-require 'aws/xray/test_socket'
+require 'aws/xray/sockets'
 
 module Aws
   module Xray

--- a/lib/aws/xray/configuration.rb
+++ b/lib/aws/xray/configuration.rb
@@ -6,8 +6,8 @@ module Aws
     # thread-unsafe, suppose to be used only in initialization phase.
     class Configuration
       option = ENV['AWS_XRAY_LOCATION']
-      DEFAULT_HOST = option ? option.split(':').first : 'localhost'
-      DEFAULT_PORT = option ? Integer(option.split(':').last) : 2000
+      DEFAULT_HOST = option ? option.split(':').first : nil
+      DEFAULT_PORT = option ? Integer(option.split(':').last) : nil
 
       name_option = ENV['AWS_XRAY_NAME']
       DEFAULT_NAME = name_option ? name_option : nil
@@ -24,9 +24,13 @@ module Aws
       # @return [Hash] client_options For xray-agent client.
       #   - host: e.g. '127.0.0.1'
       #   - port: e.g. 2000
-      #   - sock: test purpose.
       def client_options
-        @client_options ||= { host: DEFAULT_HOST, port: DEFAULT_PORT }
+        @client_options ||=
+          if DEFAULT_HOST && DEFAULT_PORT
+            { host: DEFAULT_HOST, port: DEFAULT_PORT }
+          else
+            { sock: NullSocket.new }
+          end
       end
       attr_writer :client_options
 

--- a/lib/aws/xray/sockets.rb
+++ b/lib/aws/xray/sockets.rb
@@ -13,6 +13,28 @@ module Aws
       def send(body, *)
         write(body)
       end
+
+      def close; end
+    end
+
+    class IoSocket
+      def initialize(io)
+        @io = io
+      end
+
+      def send(body, *)
+        @io.write(body)
+      end
+
+      def close; end
+    end
+
+    class NullSocket
+      def send(body, *)
+        body.size
+      end
+
+      def close; end
     end
   end
 end


### PR DESCRIPTION
We don't need tracing in development and test, so don't send tracing data using UDP socket which can be fail with `ECONNREFUSED` errono while using sendto(2) if the remote socket is absent.