### PR TITLE
Fix encoding error

### DIFF
--- a/lib/aws/xray/request.rb
+++ b/lib/aws/xray/request.rb
@@ -4,7 +4,7 @@ module Aws
     class Request < Struct.new(*attrs)
       class << self
         def build(method:, url:, user_agent: nil, client_ip: nil, x_forwarded_for: nil, traced: false)
-          new(method, url, user_agent, client_ip, x_forwarded_for, traced)
+          new(encode(method), encode(url), encode(user_agent), encode(client_ip), x_forwarded_for, traced)
         end
 
         def build_from_rack_env(env)
@@ -27,6 +27,19 @@ module Aws
             x_forwarded_for: false,
             traced: false,
           )
+        end
+
+        private
+
+        # Ensure all strings have same encoding to JSONify them.
+        # If the given string has illegal bytes or a undefined byte sequence,
+        # replace them with a default character.
+        def encode(str)
+          if str.nil?
+            nil
+          else
+            str.to_s.encode(__ENCODING__, invalid: :replace, undef: :replace)
+          end
         end
       end
     end

--- a/lib/aws/xray/request.rb
+++ b/lib/aws/xray/request.rb
@@ -2,26 +2,32 @@ module Aws
   module Xray
     attrs = [:method, :url, :user_agent, :client_ip, :x_forwarded_for, :traced]
     class Request < Struct.new(*attrs)
-      def self.build_from_rack_env(env)
-        new(
-          env['REQUEST_METHOD'], # method
-          env['REQUEST_URI'], # url
-          env['HTTP_USER_AGENT'], # user_agent
-          env['X-Forwarded-For'], # client_ip
-          !!env['X-Forwarded-For'], # x_forwarded_for
-          false, # traced
-        )
-      end
+      class << self
+        def build(method:, url:, user_agent: nil, client_ip: nil, x_forwarded_for: nil, traced: false)
+          new(method, url, user_agent, client_ip, x_forwarded_for, traced)
+        end
 
-      def self.build_from_faraday_env(env)
-        new(
-          env.method.to_s.upcase, # method
-          env.url.to_s, # url
-          env.request_headers['User-Agent'], # user_agent
-          nil, # client_ip
-          false, # x_forwarded_for
-          false, # traced
-        )
+        def build_from_rack_env(env)
+          build(
+            method: env['REQUEST_METHOD'],
+            url: env['REQUEST_URI'],
+            user_agent: env['HTTP_USER_AGENT'],
+            client_ip: env['X-Forwarded-For'],
+            x_forwarded_for: !!env['X-Forwarded-For'],
+            traced: false,
+          )
+        end
+
+        def build_from_faraday_env(env)
+          build(
+            method: env.method.to_s.upcase,
+            url: env.url.to_s,
+            user_agent: env.request_headers['User-Agent'],
+            client_ip: nil,
+            x_forwarded_for: false,
+            traced: false,
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
Strings from external, for example HTTP request, may contain illegal
bytes for default encoding which is UTF-8 in most cases. It can cause
encoding error while building a JSON string. To prevent that error,
ensure all strings which will be converted to a JSON string have same
encoding and do not contain any illegal bytes.