### PR TITLE
Longer stack traces

### DIFF
--- a/lib/aws/xray/error.rb
+++ b/lib/aws/xray/error.rb
@@ -3,7 +3,7 @@ require 'aws/xray/cause'
 module Aws
   module Xray
     class Error < Struct.new(:error, :throttle, :fault, :e, :remote, :cause)
-      MAX_BACKTRACE_SIZE = 10
+      MAX_BACKTRACE_SIZE = 250
 
       def to_h
         h = {

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe Aws::Xray::Error do
         expect(e[:message]).to eq('aaa')
         expect(e[:type]).to eq('RuntimeError')
         expect(e[:remote]).to eq(false)
-        expect(e[:truncated]).to be > 0
+        expect(e[:truncated]).to be >= 0
         expect(e[:skipped]).to eq(0)
         expect(e[:cause]).to be_nil
-        expect(e[:stack].size).to eq(10)
+        expect(e[:stack].size).to be >= 1
 
         stack = e[:stack].first
         expect(stack[:path]).to eq('spec/error_spec.rb')
@@ -56,8 +56,8 @@ RSpec.describe Aws::Xray::Error do
         expect(e[:message]).to eq('xxx')
         expect(e[:type]).to eq('test')
         expect(e[:remote]).to eq(true)
-        expect(e[:truncated]).to be > 0
-        expect(e[:stack].size).to eq(10)
+        expect(e[:truncated]).to be >= 0
+        expect(e[:stack].size).to be >= 1
       end
     end
   end

--- a/spec/faraday_spec.rb
+++ b/spec/faraday_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Aws::Xray::Faraday do
         expect(e['id']).to match(/\A[0-9a-fA-F]{16}\z/)
         expect(e['message']).to eq('Got 5xx')
         expect(e['remote']).to eq(true)
-        expect(e['stack'].size).to eq(10)
+        expect(e['stack'].size).to be >= 1
         expect(e['stack'].first['path']).to end_with('.rb')
       end
     end
@@ -168,7 +168,7 @@ RSpec.describe Aws::Xray::Faraday do
       expect(e['message']).to eq('test_error')
       expect(e['type']).to eq('RuntimeError')
       expect(e['remote']).to eq(false)
-      expect(e['stack'].size).to eq(10)
+      expect(e['stack'].size).to be >= 1
       expect(e['stack'].first['path']).to end_with('.rb')
 
       body = JSON.parse(sent_jsons[3])
@@ -187,7 +187,7 @@ RSpec.describe Aws::Xray::Faraday do
       expect(e['message']).to eq('test_error')
       expect(e['type']).to eq('RuntimeError')
       expect(e['remote']).to eq(false)
-      expect(e['stack'].size).to eq(10)
+      expect(e['stack'].size).to be >= 1
       expect(e['stack'].first['path']).to end_with('.rb')
     end
   end


### PR DESCRIPTION
Maximum segment size is 64 kB, so we can record longer stack traces.