### PR TITLE
Drop query string and fragment part of URI

### DIFF
--- a/lib/aws/xray/request.rb
+++ b/lib/aws/xray/request.rb
@@ -1,10 +1,12 @@
+require 'uri'
+
 module Aws
   module Xray
     attrs = [:method, :url, :user_agent, :client_ip, :x_forwarded_for, :traced]
     class Request < Struct.new(*attrs)
       class << self
         def build(method:, url:, user_agent: nil, client_ip: nil, x_forwarded_for: nil, traced: false)
-          new(encode(method), encode(url), encode(user_agent), encode(client_ip), x_forwarded_for, traced)
+          new(encode(method), drop_params(encode(url)), encode(user_agent), encode(client_ip), x_forwarded_for, traced)
         end
 
         def build_from_rack_env(env)
@@ -40,6 +42,15 @@ module Aws
           else
             str.to_s.encode(__ENCODING__, invalid: :replace, undef: :replace)
           end
+        end
+
+        def drop_params(str)
+          uri = URI.parse(str)
+          uri.query = nil
+          uri.fragment = nil
+          uri.to_s
+        rescue URI::InvalidURIError
+          str
         end
       end
     end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe Aws::Xray::Request do
+  describe 'serialization' do
+    context 'when illegal bytes are included in HTTP request' do
+      # \x61 = a, \xe3 = illegal bytes, \x62 = b, \x63 = c
+      let(:url) { "/user?name=\x61\xe3\x62\x63" }
+      let(:request) { described_class.build(method: 'GET', url: url) }
+
+      it 'serialized successfully' do
+        body = JSON.parse(request.to_h.to_json)
+        # \uFFFD is default unicode character in replacing illegal bytes.
+        expect(body['url']).to eq("/user?name=a\uFFFDbc")
+      end
+    end
+  end
+end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -2,15 +2,32 @@ require 'spec_helper'
 
 RSpec.describe Aws::Xray::Request do
   describe 'serialization' do
+    let(:request) { described_class.build(method: 'GET', url: url) }
+    let(:body) { JSON.parse(request.to_h.to_json) }
+
     context 'when illegal bytes are included in HTTP request' do
       # \x61 = a, \xe3 = illegal bytes, \x62 = b, \x63 = c
-      let(:url) { "/user?name=\x61\xe3\x62\x63" }
-      let(:request) { described_class.build(method: 'GET', url: url) }
+      let(:url) { "/users/\x61\xe3\x62\x63/" }
 
       it 'serialized successfully' do
-        body = JSON.parse(request.to_h.to_json)
         # \uFFFD is default unicode character in replacing illegal bytes.
-        expect(body['url']).to eq("/user?name=a\uFFFDbc")
+        expect(body['url']).to eq("/users/a\uFFFDbc/")
+      end
+    end
+
+    context 'when request parameters are given' do
+      let(:url) { '/user?name=alice' }
+
+      it 'drops the request parameters' do
+        expect(body['url']).to eq('/user')
+      end
+    end
+
+    context 'when a given uri has fragment part' do
+      let(:url) { '/user?name=alice#token=xxx' }
+
+      it 'drops the fragment part' do
+        expect(body['url']).to eq('/user')
       end
     end
   end

--- a/spec/segment_spec.rb
+++ b/spec/segment_spec.rb
@@ -21,21 +21,6 @@ RSpec.describe Aws::Xray::Segment do
       expect(segment.to_h.has_key?(:in_progress)).to eq(false)
       expect(segment.to_h.has_key?(:end_time)).to eq(true)
     end
-
-    context 'when illegal bytes are included in HTTP request' do
-      # \x61 = a, \xe3 = illegal bytes, \x62 = b, \x63 = c
-      let(:url) { "/user?name=\x61\xe3\x62\x63" }
-      let(:request) { Aws::Xray::Request.build(method: 'GET', url: url) }
-
-      it 'serialized successfully' do
-        segment = described_class.build('test-app', trace)
-        segment.set_http_request(request)
-        body = JSON.parse(segment.to_json)
-        expect(body['name']).to eq('test-app')
-        # \uFFFD is default unicode character in replacing illegal bytes.
-        expect(body['http']['request']['url']).to eq("/user?name=a\uFFFDbc")
-      end
-    end
   end
 
   describe '#add_annotation' do


### PR DESCRIPTION
X-Ray requires the `url` property must be "The full URL of the request, compiled from the protocol, hostname, and path of the request.". So drop query string and fragment part from given URI.