### PR TITLE
Do not freeze string from SecureRandom.hex

### DIFF
--- a/lib/aws/xray/context.rb
+++ b/lib/aws/xray/context.rb
@@ -87,7 +87,7 @@ module Aws
       # @return [Object] A value which given block returns.
       def base_trace
         base_segment = Segment.build(@name, @trace)
-        @base_segment_id = base_segment.id.freeze
+        @base_segment_id = base_segment.id.dup
 
         begin
           yield base_segment


### PR DESCRIPTION
It can be ambitious error from AD session store:

    RuntimeError (can't modify frozen String):
        actionpack (4.2.7.1) lib/action_dispatch/middleware/session/abstract_store.rb:29:in `encode!'
        actionpack (4.2.7.1) lib/action_dispatch/middleware/session/abstract_store.rb:29:in `generate_sid'
        actionpack (4.2.7.1) lib/action_dispatch/middleware/session/cookie_store.rb:100:in `persistent_session_id!'
        actionpack (4.2.7.1) lib/action_dispatch/middleware/session/cookie_store.rb:74:in `block in load_session'
        actionpack (4.2.7.1) lib/action_dispatch/middleware/session/abstract_store.rb:51:in `stale_session_check!'
        actionpack (4.2.7.1) lib/action_dispatch/middleware/session/cookie_store.rb:72:in `load_session'
        actionpack (4.2.7.1) lib/action_dispatch/request/session.rb:180:in `load!'
        actionpack (4.2.7.1) lib/action_dispatch/request/session.rb:176:in `load_for_write!'
        actionpack (4.2.7.1) lib/action_dispatch/request/session.rb:129:in `delete'

https://github.com/rails/rails/blob/v4.2.7.1/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb#L28-L29