### PR TITLE
Mark error with checking rack response

### DIFF
--- a/lib/aws/xray/faraday.rb
+++ b/lib/aws/xray/faraday.rb
@@ -23,20 +23,7 @@ module Aws
 
           res = Context.current.disable_trace(:net_http) { @app.call(req_env) }
           res.on_complete do |res_env|
-            sub.set_http_response(res_env.status, res_env.response_headers['Content-Length'])
-            case res_env.status
-            when 499
-              cause = Cause.new(stack: caller, message: 'Got 499', type: 'http_request_error')
-              sub.set_error(error: true, throttle: true, cause: cause)
-            when 400..498
-              cause = Cause.new(stack: caller, message: 'Got 4xx', type: 'http_request_error')
-              sub.set_error(error: true, cause: cause)
-            when 500..599
-              cause = Cause.new(stack: caller, message: 'Got 5xx', type: 'http_request_error')
-              sub.set_error(fault: true, remote: true, cause: cause)
-            else
-              # pass
-            end
+            sub.set_http_response_with_error(res_env.status, res_env.response_headers['Content-Length'], remote: true)
           end
         end
       end

--- a/lib/aws/xray/hooks/net_http.rb
+++ b/lib/aws/xray/hooks/net_http.rb
@@ -28,21 +28,7 @@ module Aws
 
             res = request_without_aws_xray(req, *args, &block)
 
-            sub.set_http_response(res.code.to_i, res['Content-Length'])
-            case res.code.to_i
-            when 499
-              cause = Cause.new(stack: caller, message: 'Got 499', type: 'http_request_error')
-              sub.set_error(error: true, throttle: true, cause: cause)
-            when 400..498
-              cause = Cause.new(stack: caller, message: 'Got 4xx', type: 'http_request_error')
-              sub.set_error(error: true, cause: cause)
-            when 500..599
-              cause = Cause.new(stack: caller, message: 'Got 5xx', type: 'http_request_error')
-              sub.set_error(fault: true, remote: true, cause: cause)
-            else
-              # pass
-            end
-
+            sub.set_http_response_with_error(res.code.to_i, res['Content-Length'], remote: true)
             res
           end
         end

--- a/lib/aws/xray/rack.rb
+++ b/lib/aws/xray/rack.rb
@@ -39,7 +39,8 @@ module Aws
           Context.current.base_trace do |seg|
             seg.set_http_request(Request.build_from_rack_env(env))
             status, headers, body = @app.call(env)
-            seg.set_http_response(status, headers['Content-Length'] || 0)
+            length = headers['Content-Length'] || 0
+            seg.set_http_response_with_error(status, length, remote: false)
             headers[TRACE_HEADER] = trace.to_header_value
             [status, headers, body]
           end


### PR DESCRIPTION
Previously, aws-xray does not mark segments as errors when rack app
returens 500 response or so. These segments should be marked as errors.