### PR TITLE
Record rack-timeout's exception

### DIFF
--- a/aws-xray.gemspec
+++ b/aws-xray.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rack-test'
+  spec.add_development_dependency 'rack-timeout'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
 end

--- a/lib/aws/xray/context.rb
+++ b/lib/aws/xray/context.rb
@@ -86,8 +86,8 @@ module Aws
         self.class.new(@name.dup, @client.copy, @trace.copy, @base_segment_id ? @base_segment_id.dup : nil)
       end
 
-      # Rescue standard errors and record the error to the segment.
-      # Then re-raise the error.
+      # Rescue all exceptions and record the exception to the segment.
+      # Then re-raise the exception.
       #
       # @yield [Aws::Xray::Segment]
       # @return [Object] A value which given block returns.
@@ -97,7 +97,7 @@ module Aws
 
         begin
           yield base_segment
-        rescue => e
+        rescue Exception => e
           base_segment.set_error(fault: true, e: e)
           raise e
         ensure
@@ -106,9 +106,6 @@ module Aws
         end
       end
 
-      # Rescue standard errors and record the error to the sub segment.
-      # Then re-raise the error.
-      #
       # @param [Boolean] remote
       # @param [String] name Arbitrary name of the sub segment. e.g. "funccall_f".
       # @yield [Aws::Xray::SubSegment]
@@ -119,7 +116,7 @@ module Aws
 
         begin
           yield sub
-        rescue => e
+        rescue Exception => e
           sub.set_error(fault: true, e: e)
           raise e
         ensure

--- a/spec/aws_xray_spec.rb
+++ b/spec/aws_xray_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper'
+require 'timeout'
 
 RSpec.describe Aws::Xray do
   describe '.trace' do
-    context 'when succeed' do
-      before do
-        allow(Aws::Xray.config).to receive(:client_options).and_return(client_options)
-      end
-      let(:client_options) { { sock: io } }
-      let(:io) { Aws::Xray::TestSocket.new }
+    before do
+      allow(Aws::Xray.config).to receive(:client_options).and_return(client_options)
+    end
+    let(:client_options) { { sock: io } }
+    let(:io) { Aws::Xray::TestSocket.new }
 
+    context 'when succeed' do
       it 'starts tracing' do
         Aws::Xray.trace(name: 'test') {}
         expect(io.tap(&:rewind).read.split("\n").size).to eq(2)
@@ -24,6 +25,23 @@ RSpec.describe Aws::Xray do
 
       it 'raises MissingNameError' do
         expect { Aws::Xray.trace {} }.to raise_error(Aws::Xray::MissingNameError)
+      end
+    end
+
+    context 'when timeout error is raised' do
+      it 'captures the error' do
+        expect {
+          Aws::Xray.trace(name: 'test') do
+            Timeout.timeout(0.01) do
+              sleep 0.03
+            end
+          end
+        }.to raise_error(Timeout::Error)
+        sent_jsons = io.tap(&:rewind).read.split("\n")
+        expect(sent_jsons.size).to eq(2)
+
+        body = JSON.parse(sent_jsons[1])
+        expect(body['fault']).to eq(true)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,7 @@ RSpec.configure do |config|
 
   config.disable_monkey_patching!
 
-  config.warnings = true
+  config.warnings = false # because of rack-timeout
 
   if config.files_to_run.one?
     config.default_formatter = 'doc'


### PR DESCRIPTION
rack-timeout raises exception instead of standard error to prevent an application from catching the error: https://github.com/heroku/rack-timeout/blob/7e14d29accc0da2a2ca0400cc8bee2c277b77e12/lib/rack/timeout/core.rb#L24