### PR TITLE
To be non-blocking

### DIFF
--- a/lib/aws/xray.rb
+++ b/lib/aws/xray.rb
@@ -1,4 +1,5 @@
 require 'aws/xray/version'
+require 'aws/xray/errors'
 require 'aws/xray/rack'
 require 'aws/xray/faraday'
 require 'aws/xray/configuration'
@@ -7,12 +8,6 @@ require 'aws/xray/sockets'
 module Aws
   module Xray
     TRACE_HEADER = 'X-Amzn-Trace-Id'.freeze
-
-    class MissingNameError < ::StandardError
-      def initialize
-        super("`name` is empty. Configure this with `Aws::Xray.config.name = 'my-app'`.")
-      end
-    end
 
     @config = Configuration.new
     class << self

--- a/lib/aws/xray/client.rb
+++ b/lib/aws/xray/client.rb
@@ -22,7 +22,7 @@ module Aws
         sock = @sock || UDPSocket.new
 
         begin
-          len = sock.send(payload, 0, @host, @port)
+          len = sock.send(payload, Socket::MSG_DONTWAIT, @host, @port)
           $stderr.puts("Can not send all bytes: #{len} sent") if payload.size != len
         rescue SystemCallError, SocketError => e
           begin

--- a/lib/aws/xray/client.rb
+++ b/lib/aws/xray/client.rb
@@ -23,8 +23,9 @@ module Aws
 
         begin
           len = sock.send(payload, Socket::MSG_DONTWAIT, @host, @port)
-          $stderr.puts("Can not send all bytes: #{len} sent") if payload.size != len
-        rescue SystemCallError, SocketError => e
+          raise CanNotSendAllByteError.new(payload.size, len) if payload.size != len
+          len
+        rescue SystemCallError, SocketError, CanNotSendAllByteError => e
           begin
             Aws::Xray.config.segment_sending_error_handler.call(e, payload, host: @host, port: @port)
           rescue Exception => e

--- a/lib/aws/xray/context.rb
+++ b/lib/aws/xray/context.rb
@@ -6,20 +6,6 @@ module Aws
     class Context
       VAR_NAME = :_aws_xray_context_
 
-      class BaseError < ::StandardError; end
-
-      class NotSetError < BaseError
-        def initialize
-          super('Context is not set for this thread')
-        end
-      end
-
-      class SegmentDidNotStartError < BaseError
-        def initialize
-          super('Segment did not start yet')
-        end
-      end
-
       class << self
         # @return [Aws::Xray::Context]
         def current

--- a/lib/aws/xray/errors.rb
+++ b/lib/aws/xray/errors.rb
@@ -20,5 +20,11 @@ module Aws
         super("`name` is empty. Configure this with `Aws::Xray.config.name = 'my-app'`.")
       end
     end
+
+    class CanNotSendAllByteError < BaseError
+      def initialize(payload_len, sent_len)
+        super("Can not send all bytes: expected #{payload_len} but #{sent_len} sent")
+      end
+    end
   end
 end

--- a/lib/aws/xray/errors.rb
+++ b/lib/aws/xray/errors.rb
@@ -1,0 +1,24 @@
+module Aws
+  module Xray
+    # Bacause we already had another `Error` class for domain object.
+    class BaseError < ::StandardError; end
+
+    class NotSetError < BaseError
+      def initialize
+        super('Context is not set for this thread')
+      end
+    end
+
+    class SegmentDidNotStartError < BaseError
+      def initialize
+        super('Segment did not start yet')
+      end
+    end
+
+    class MissingNameError < BaseError
+      def initialize
+        super("`name` is empty. Configure this with `Aws::Xray.config.name = 'my-app'`.")
+      end
+    end
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -65,6 +65,17 @@ RSpec.describe Aws::Xray::Client do
       end
     end
 
+    context 'when can not send all bytes' do
+      let(:sock) { double('sock', close: nil) }
+      before { allow(sock).to receive(:send).and_return(0) }
+
+      it 'raises CanNotSendAllByteError' do
+        client = described_class.new(sock: sock)
+        client.send_segment(segment)
+        expect(io.tap(&:rewind).read).to match(/Can not send all bytes/)
+      end
+    end
+
     context 'when error handler raises errors' do
       around do |ex|
         back = Aws::Xray.config.segment_sending_error_handler

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Aws::Xray::Context do
         expect(Aws::Xray::Context.current).to be_a(Aws::Xray::Context)
         expect {
           Thread.new { Aws::Xray::Context.current }.join
-        }.to raise_error(Aws::Xray::Context::NotSetError)
+        }.to raise_error(Aws::Xray::NotSetError)
       end
     end
 


### PR DESCRIPTION
This library should not block application logic, so simply specify non-blocking flag to sendto(2) and if the operation which about to doing will block, just give up to send the message and pass the error to error handlers.