### PR TITLE
Require aws/xray in hooks

### DIFF
--- a/lib/aws/xray/hooks/all.rb
+++ b/lib/aws/xray/hooks/all.rb
@@ -1,1 +1,2 @@
+require 'aws/xray'
 require 'aws/xray/hooks/net_http'

--- a/lib/aws/xray/hooks/net_http.rb
+++ b/lib/aws/xray/hooks/net_http.rb
@@ -1,3 +1,4 @@
+require 'aws/xray'
 require 'net/http'
 
 module Aws


### PR DESCRIPTION
With this, we can simply write `require: 'aws/xray/hooks/all'` in
a Gemfile.