### PR TITLE
Test case for given double quotes

### DIFF
--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe Aws::Xray::Configuration do
       end
     end
 
+    context 'when doueble quotes are given' do
+      let(:location) { '""' }
+
+      it 'returns default one' do
+        expect(Aws::Xray::Configuration.new.client_options).to match(sock: be_a(Aws::Xray::NullSocket))
+      end
+    end
+
     context 'when nothing is given' do
       let(:location) { nil }
 


### PR DESCRIPTION
In case aws-xray are given `AWS_XRAY_LOCATION=""` in `.env` file.