### PR TITLE
Clear queue and workers after forked

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
-require 'pry'
 require 'coveralls'
 Coveralls.wear!
+
+require 'pry'
 
 $:.unshift File.expand_path('../lib', __dir__)
 require 'aws/xray'


### PR DESCRIPTION
After fork(2) was called, all other threads except main thread are not
copied in most environments. That fork can be called by unicorn or
resque or etc. So we have to ensure our worker threads can perform jobs
after forked. To do that, clear all the workers and the queue copied
from forking process and reset them in forked process.