### PR TITLE
Stop passing Client instance

### DIFF
--- a/lib/aws/xray.rb
+++ b/lib/aws/xray.rb
@@ -26,8 +26,7 @@ module Aws
     # @param [String] name a logical name of this tracing context.
     def self.trace(name: nil)
       name = name || config.name || raise(MissingNameError)
-      client = Client.new(Aws::Xray.config.client_options)
-      Context.with_new_context(name, client, Trace.generate) do
+      Context.with_new_context(name, Trace.generate) do
         Context.current.base_trace do |seg|
           yield seg
         end

--- a/lib/aws/xray/client.rb
+++ b/lib/aws/xray/client.rb
@@ -5,58 +5,51 @@ module Aws
     # Own the responsibility of holding destination address and sending
     # segments.
     class Client
-      # sock is for test.
-      def initialize(host: nil, port: nil, sock: nil)
-        @host, @port = host, port
-        @sock = sock
-      end
+      class << self
+        # @param [Aws::Xray::Segment] segment
+        def send_segment(segment)
+          Aws::Xray.config.logger.debug("#{Thread.current}: Client.send_segment started")
+          payload = %!{"format": "json", "version": 1}\n#{segment.to_json}\n!
 
-      def copy
-        self.class.new(host: @host ? @host.dup : nil, port: @port, sock: @sock)
-      end
-
-      # When UDPSocket#send can not send all bytes, just give up it.
-      # @param [Aws::Xray::Segment] segment
-      def send_segment(segment)
-        Aws::Xray.config.logger.debug("#{Thread.current}: Client#send_segment started")
-        payload = %!{"format": "json", "version": 1}\n#{segment.to_json}\n!
-
-        begin
-          if @sock # test env or not aws-xray is not enabled
-            send_payload(payload)
-            Aws::Xray.config.logger.debug("#{Thread.current}: Client#send_segment called #send_payload in the same thread")
-          else # production env
-            Worker.post(payload, self.copy)
-            Aws::Xray.config.logger.debug("#{Thread.current}: Client#send_segment posted a job to worker")
-          end
-        rescue QueueIsFullError => e
           begin
-            Aws::Xray.config.segment_sending_error_handler.call(e, payload, host: @host, port: @port)
-          rescue Exception => e
-            $stderr.puts("Error handler `#{Aws::Xray.config.segment_sending_error_handler}` raised an error: #{e}\n#{e.backtrace.join("\n")}")
+            if Aws::Xray.config.client_options[:sock] # test env or not aws-xray is not enabled
+              send_payload(payload)
+              Aws::Xray.config.logger.debug("#{Thread.current}: Client.send_segment called #send_payload in the same thread")
+            else # production env
+              Worker.post(payload)
+              Aws::Xray.config.logger.debug("#{Thread.current}: Client.send_segment posted a job to worker")
+            end
+          rescue QueueIsFullError => e
+            begin
+              host, port = Aws::Xray.config.client_options[:host], Aws::Xray.config.client_options[:port]
+              Aws::Xray.config.segment_sending_error_handler.call(e, payload, host: host, port: port)
+            rescue Exception => e
+              $stderr.puts("Error handler `#{Aws::Xray.config.segment_sending_error_handler}` raised an error: #{e}\n#{e.backtrace.join("\n")}")
+            end
           end
         end
-      end
 
-      # Will be called in other threads.
-      # @param [String] payload
-      def send_payload(payload)
-        Aws::Xray.config.logger.debug("#{Thread.current}: Client#send_payload")
-        sock = @sock || UDPSocket.new
+        # Will be called in other threads.
+        # @param [String] payload
+        def send_payload(payload)
+          Aws::Xray.config.logger.debug("#{Thread.current}: Client#send_payload")
+          sock = Aws::Xray.config.client_options[:sock] || UDPSocket.new
+          host, port = Aws::Xray.config.client_options[:host], Aws::Xray.config.client_options[:port]
 
-        begin
-          len = sock.send(payload, Socket::MSG_DONTWAIT, @host, @port)
-          raise CanNotSendAllByteError.new(payload.size, len) if payload.size != len
-          Aws::Xray.config.logger.debug("#{Thread.current}: Client#send_payload successfully sent payload, len=#{len}")
-          len
-        rescue SystemCallError, SocketError, CanNotSendAllByteError => e
           begin
-            Aws::Xray.config.segment_sending_error_handler.call(e, payload, host: @host, port: @port)
-          rescue Exception => e
-            $stderr.puts("Error handler `#{Aws::Xray.config.segment_sending_error_handler}` raised an error: #{e}\n#{e.backtrace.join("\n")}")
+            len = sock.send(payload, Socket::MSG_DONTWAIT, host, port)
+            raise CanNotSendAllByteError.new(payload.size, len) if payload.size != len
+            Aws::Xray.config.logger.debug("#{Thread.current}: Client#send_payload successfully sent payload, len=#{len}")
+            len
+          rescue SystemCallError, SocketError, CanNotSendAllByteError => e
+            begin
+              Aws::Xray.config.segment_sending_error_handler.call(e, payload, host: host, port: port)
+            rescue Exception => e
+              $stderr.puts("Error handler `#{Aws::Xray.config.segment_sending_error_handler}` raised an error: #{e}\n#{e.backtrace.join("\n")}")
+            end
+          ensure
+            sock.close
           end
-        ensure
-          sock.close
         end
       end
     end

--- a/spec/faraday_spec.rb
+++ b/spec/faraday_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe Aws::Xray::Faraday do
     end
   end
   let(:headers) { { 'Host' => 'target-app' } }
-  let(:xray_client) { Aws::Xray::Client.new(sock: io) }
-  let(:io) { Aws::Xray::TestSocket.new }
   let(:trace) { Aws::Xray::Trace.new(root: '1-67891233-abcdef012345678912345678') }
+  let(:io) { Aws::Xray::TestSocket.new }
+  before { allow(Aws::Xray.config).to receive(:client_options).and_return(sock: io) }
 
   context 'without name option' do
     it 'uses host header value' do
-      res = Aws::Xray::Context.with_new_context('test-app', xray_client, trace) do
+      res = Aws::Xray::Context.with_new_context('test-app', trace) do
         Aws::Xray::Context.current.base_trace do
           client.get('/foo')
         end
@@ -67,7 +67,7 @@ RSpec.describe Aws::Xray::Faraday do
         builder.adapter :test, stubs
       end
 
-      res = Aws::Xray::Context.with_new_context('test-app', xray_client, trace) do
+      res = Aws::Xray::Context.with_new_context('test-app', trace) do
         Aws::Xray::Context.current.base_trace do
           client.get('/foo')
         end
@@ -94,7 +94,7 @@ RSpec.describe Aws::Xray::Faraday do
       end
 
       it 'traces remote fault' do
-        res = Aws::Xray::Context.with_new_context('test-app', xray_client, trace) do
+        res = Aws::Xray::Context.with_new_context('test-app', trace) do
           Aws::Xray::Context.current.base_trace do
             client.get('/foo')
           end
@@ -132,7 +132,7 @@ RSpec.describe Aws::Xray::Faraday do
       end
 
       it 'traces remote fault' do
-        res = Aws::Xray::Context.with_new_context('test-app', xray_client, trace) do
+        res = Aws::Xray::Context.with_new_context('test-app', trace) do
           Aws::Xray::Context.current.base_trace do
             client.get('/foo')
           end
@@ -160,7 +160,7 @@ RSpec.describe Aws::Xray::Faraday do
       end
 
       it 'traces remote fault' do
-        res = Aws::Xray::Context.with_new_context('test-app', xray_client, trace) do
+        res = Aws::Xray::Context.with_new_context('test-app', trace) do
           Aws::Xray::Context.current.base_trace do
             client.get('/foo')
           end
@@ -190,7 +190,7 @@ RSpec.describe Aws::Xray::Faraday do
 
     it 'traces remote fault' do
       expect {
-        Aws::Xray::Context.with_new_context('test-app', xray_client, trace) do
+        Aws::Xray::Context.with_new_context('test-app', trace) do
           Aws::Xray::Context.current.base_trace do
             client.get('/foo')
           end
@@ -249,7 +249,7 @@ RSpec.describe Aws::Xray::Faraday do
     end
 
     it 'accepts name parameter' do
-      res = Aws::Xray::Context.with_new_context('test-app', xray_client, trace) do
+      res = Aws::Xray::Context.with_new_context('test-app', trace) do
         Aws::Xray::Context.current.base_trace do
           client.get('/foo')
         end

--- a/spec/net_http_hook_spec.rb
+++ b/spec/net_http_hook_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 RSpec.describe Aws::Xray::Hooks::NetHttp do
   before do
     Thread.abort_on_exception = true
+    allow(Aws::Xray.config).to receive(:client_options).and_return(sock: io)
   end
 
-  let(:xray_client) { Aws::Xray::Client.new(sock: io) }
   let(:io) { Aws::Xray::TestSocket.new }
   let(:trace) { Aws::Xray::Trace.new(root: '1-67891233-abcdef012345678912345678') }
   let(:host) { '127.0.0.1' }
@@ -25,7 +25,7 @@ RSpec.describe Aws::Xray::Hooks::NetHttp do
 
   def build_client_thread(&block)
     Thread.new(block) do
-      Aws::Xray::Context.with_new_context('test-app', xray_client, trace) do
+      Aws::Xray::Context.with_new_context('test-app', trace) do
         Aws::Xray::Context.current.base_trace do
           block.call
         end


### PR DESCRIPTION
Because now we stop sharing socket object between tracing context.