### PR TITLE
Fix sampling bug

### DIFF
--- a/lib/aws/xray/trace.rb
+++ b/lib/aws/xray/trace.rb
@@ -7,7 +7,7 @@ module Aws
     class Trace
       class << self
         def generate(now = Time.now)
-          new(root: generate_root(now))
+          new(root: generate_root(now), sampled: decide_sampling(nil))
         end
 
         def build_from_header_value(header_value, now = Time.now)
@@ -41,7 +41,7 @@ module Aws
 
       attr_reader :root, :parent
 
-      def initialize(root:, sampled: true, parent: nil)
+      def initialize(root:, sampled:, parent: nil)
         @root = root
         @sampled = sampled
         @parent = parent

--- a/spec/faraday_spec.rb
+++ b/spec/faraday_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Aws::Xray::Faraday do
     end
   end
   let(:headers) { { 'Host' => 'target-app' } }
-  let(:trace) { Aws::Xray::Trace.new(root: '1-67891233-abcdef012345678912345678') }
+  let(:trace) { Aws::Xray::Trace.new(root: '1-67891233-abcdef012345678912345678', sampled: true) }
   let(:io) { Aws::Xray::TestSocket.new }
   before { allow(Aws::Xray.config).to receive(:client_options).and_return(sock: io) }
 

--- a/spec/net_http_hook_spec.rb
+++ b/spec/net_http_hook_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Aws::Xray::Hooks::NetHttp do
   end
 
   let(:io) { Aws::Xray::TestSocket.new }
-  let(:trace) { Aws::Xray::Trace.new(root: '1-67891233-abcdef012345678912345678') }
+  let(:trace) { Aws::Xray::Trace.new(root: '1-67891233-abcdef012345678912345678', sampled: true) }
   let(:host) { '127.0.0.1' }
   let(:server) { TCPServer.new(0) }
   let(:port) { server.addr[1] }

--- a/spec/segment_spec.rb
+++ b/spec/segment_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Aws::Xray::Segment do
-  let(:trace) { Aws::Xray::Trace.new(root: '1-67891233-abcdef012345678912345678', parent: 'd5058bbe22392c37') }
+  let(:trace) { Aws::Xray::Trace.new(root: '1-67891233-abcdef012345678912345678', parent: 'd5058bbe22392c37', sampled: true) }
 
   describe 'serialization' do
     it 'serialized properly' do

--- a/spec/subsegment_spec.rb
+++ b/spec/subsegment_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Aws::Xray::Subsegment do
-  let(:trace) { Aws::Xray::Trace.new(root: '1-67891233-abcdef012345678912345678', parent: 'd5058bbe22392c37') }
+  let(:trace) { Aws::Xray::Trace.new(root: '1-67891233-abcdef012345678912345678', parent: 'd5058bbe22392c37', sampled: true) }
   let(:segment) { Aws::Xray::Segment.build('test-app', trace) }
 
   describe 'serialization' do


### PR DESCRIPTION
When trace header is missing, aws-xray generates a trace which always
has sampled value as true. To fix this bug, stop setting default value
for `sampled` argument and set proper `sampled` value with
`decide_sampling` method.