### PR TITLE
Rename tracing methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ end
 Aws::Xray.trace(name: 'my-app-batch') do |seg|
   client.get('/foo')
 
-  Aws::Xray::Context.current.child_trace(name: 'fetch-user', remote: true) do |sub|
+  Aws::Xray::Context.current.start_subsegment(name: 'fetch-user', remote: true) do |sub|
     # DB access or something to trace.
   end
 end

--- a/lib/aws/xray.rb
+++ b/lib/aws/xray.rb
@@ -26,7 +26,7 @@ module Aws
     def self.trace(name: nil)
       name = name || config.name || raise(MissingNameError)
       Context.with_new_context(name, Trace.generate) do
-        Context.current.base_trace do |seg|
+        Context.current.start_segment do |seg|
           yield seg
         end
       end

--- a/lib/aws/xray/context.rb
+++ b/lib/aws/xray/context.rb
@@ -74,7 +74,7 @@ module Aws
       #
       # @yield [Aws::Xray::Segment]
       # @return [Object] A value which given block returns.
-      def base_trace
+      def start_segment
         base_segment = Segment.build(@name, @trace)
         @base_segment_id = base_segment.id
 
@@ -88,12 +88,13 @@ module Aws
           Client.send_segment(base_segment) if @trace.sampled?
         end
       end
+      alias_method :base_trace, :start_segment
 
       # @param [Boolean] remote
       # @param [String] name Arbitrary name of the sub segment. e.g. "funccall_f".
       # @yield [Aws::Xray::Subsegment]
       # @return [Object] A value which given block returns.
-      def child_trace(remote:, name:)
+      def start_subsegment(remote:, name:)
         raise SegmentDidNotStartError unless @base_segment_id
         sub = Subsegment.build(@trace, @base_segment_id, remote: remote, name: overwrite_name(name))
 
@@ -107,6 +108,7 @@ module Aws
           Client.send_segment(sub) if @trace.sampled?
         end
       end
+      alias_method :child_trace, :start_subsegment
 
       # Temporary disabling tracing for given id in given block.
       # CAUTION: the disabling will NOT be propagated between threads!!

--- a/lib/aws/xray/faraday.rb
+++ b/lib/aws/xray/faraday.rb
@@ -17,7 +17,7 @@ module Aws
 
         name = @name || req_env.request_headers['Host'] || "unknown-request-from-#{Context.current.name}"
 
-        Context.current.child_trace(remote: true, name: name) do |sub|
+        Context.current.start_subsegment(remote: true, name: name) do |sub|
           propagate_trace = sub.generate_trace
           req_env.request_headers[TRACE_HEADER] = propagate_trace.to_header_value
           sub.set_http_request(Request.build_from_faraday_env(req_env))

--- a/lib/aws/xray/hooks/net_http.rb
+++ b/lib/aws/xray/hooks/net_http.rb
@@ -22,7 +22,7 @@ module Aws
             user_agent: req['User-Agent'],
           )
           name = req[NAME_HEADER] || req['Host'] || address
-          Context.current.child_trace(remote: true, name: name) do |sub|
+          Context.current.start_subsegment(remote: true, name: name) do |sub|
             propagate_trace = sub.generate_trace
             req[TRACE_HEADER] = propagate_trace.to_header_value
             sub.set_http_request(request_record)

--- a/lib/aws/xray/rack.rb
+++ b/lib/aws/xray/rack.rb
@@ -27,7 +27,7 @@ module Aws
         env[TRACE_ENV] = trace.to_header_value
 
         Context.with_new_context(@name, trace) do
-          Context.current.base_trace do |seg|
+          Context.current.start_segment do |seg|
             seg.set_http_request(Request.build_from_rack_env(env))
             status, headers, body = @app.call(env)
             length = headers['Content-Length'] || 0

--- a/spec/aws_xray_spec.rb
+++ b/spec/aws_xray_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Aws::Xray do
       it 'overwrites name' do
         Aws::Xray.trace(name: 'test') do
           Aws::Xray.overwrite(name: 'overwrite') do
-            Aws::Xray::Context.current.child_trace(name: 'name1', remote: false) {}
+            Aws::Xray::Context.current.start_subsegment(name: 'name1', remote: false) {}
           end
         end
 

--- a/spec/faraday_spec.rb
+++ b/spec/faraday_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Aws::Xray::Faraday do
   context 'without name option' do
     it 'uses host header value' do
       res = Aws::Xray::Context.with_new_context('test-app', trace) do
-        Aws::Xray::Context.current.base_trace do
+        Aws::Xray::Context.current.start_segment do
           client.get('/foo')
         end
       end
@@ -69,7 +69,7 @@ RSpec.describe Aws::Xray::Faraday do
       end
 
       res = Aws::Xray::Context.with_new_context('test-app', trace) do
-        Aws::Xray::Context.current.base_trace do
+        Aws::Xray::Context.current.start_segment do
           client.get('/foo')
         end
       end
@@ -96,7 +96,7 @@ RSpec.describe Aws::Xray::Faraday do
 
       it 'traces remote fault' do
         res = Aws::Xray::Context.with_new_context('test-app', trace) do
-          Aws::Xray::Context.current.base_trace do
+          Aws::Xray::Context.current.start_segment do
             client.get('/foo')
           end
         end
@@ -134,7 +134,7 @@ RSpec.describe Aws::Xray::Faraday do
 
       it 'traces remote fault' do
         res = Aws::Xray::Context.with_new_context('test-app', trace) do
-          Aws::Xray::Context.current.base_trace do
+          Aws::Xray::Context.current.start_segment do
             client.get('/foo')
           end
         end
@@ -162,7 +162,7 @@ RSpec.describe Aws::Xray::Faraday do
 
       it 'traces remote fault' do
         res = Aws::Xray::Context.with_new_context('test-app', trace) do
-          Aws::Xray::Context.current.base_trace do
+          Aws::Xray::Context.current.start_segment do
             client.get('/foo')
           end
         end
@@ -192,7 +192,7 @@ RSpec.describe Aws::Xray::Faraday do
     it 'traces remote fault' do
       expect {
         Aws::Xray::Context.with_new_context('test-app', trace) do
-          Aws::Xray::Context.current.base_trace do
+          Aws::Xray::Context.current.start_segment do
             client.get('/foo')
           end
         end
@@ -251,7 +251,7 @@ RSpec.describe Aws::Xray::Faraday do
 
     it 'accepts name parameter' do
       res = Aws::Xray::Context.with_new_context('test-app', trace) do
-        Aws::Xray::Context.current.base_trace do
+        Aws::Xray::Context.current.start_segment do
           client.get('/foo')
         end
       end

--- a/spec/net_http_hook_spec.rb
+++ b/spec/net_http_hook_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Aws::Xray::Hooks::NetHttp do
   def build_client_thread(&block)
     Thread.new(block) do
       Aws::Xray::Context.with_new_context('test-app', trace) do
-        Aws::Xray::Context.current.base_trace do
+        Aws::Xray::Context.current.start_segment do
           block.call
         end
       end

--- a/spec/rack_spec.rb
+++ b/spec/rack_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Aws::Xray::Rack do
       builder = Rack::Builder.new
       builder.use described_class
       builder.run -> (_) {
-        Aws::Xray::Context.current.child_trace(remote: false, name: 'funccall_f') {}
+        Aws::Xray::Context.current.start_subsegment(remote: false, name: 'funccall_f') {}
         [200, {}, ['hello']]
       }
       builder


### PR DESCRIPTION
`#base_trace` and `#child_trace` are not clear or intuitive name.