### PR TITLE
Change default sampling rate to undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,13 +157,9 @@ docker run --link xray:xray --env AWS_XRAY_LOCATION=xray:2000 my-application
 ### Sampling
 Sampling rate should be a float within 0 to 1. Both 0 and 1 are acceptable.
 e.g. 0 means never sampled, 1 means always sampled, 0.3 means 30% of requests (or traces in not Rack app) will be sampled.
-The default sampling rate is `0.001`, which means 0.1% of requests will be sampled.
+The default sampling rate is undefined so you should set your own sampling rate on production system. 
 
-Set sampling rate with `AWS_XRAY_SAMPLING_RATE` env var or:
-
-```ruby
-Aws::Xray.config.sampling_rate = 0.1
-```
+Set sampling rate with `AWS_XRAY_SAMPLING_RATE` env var.
 
 ### Excluded paths
 To avoid tracing health checking requests, use "excluded paths" configuration.

--- a/lib/aws/xray/configuration.rb
+++ b/lib/aws/xray/configuration.rb
@@ -39,7 +39,7 @@ module Aws
         @default_metadata = DEFAULT_METADATA
         @segment_sending_error_handler = DefaultErrorHandler.new($stderr)
         @worker = Aws::Xray::Worker::Configuration.new
-        @sampling_rate = Float(ENV['AWS_XRAY_SAMPLING_RATE'] || 0.001)
+        @sampling_rate = Float(ENV['AWS_XRAY_SAMPLING_RATE'] || 1.0)
         @solr_hook_name = 'solr'
         @record_caller_of_http_requests = false
       end
@@ -92,7 +92,7 @@ module Aws
         conf
       end
 
-      # Default is 0.1%.
+      # Default is undefined.
       # @param [Float] sampling_rate
       # @return [Float]
       attr_accessor :sampling_rate


### PR DESCRIPTION
Since this value is operational and has impact to production systems
users should not rely this default behavior. Actually we set default
value as `1` to make local development easier.