### PR TITLE
Control passing trace header to down stream services

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,12 @@ response = Aws::Xray.overwrite(name: 'sns') do
 end
 ```
 
+If you do not want to pass trace header to other services, control with `Aws::Xray.config.trace_header_excluded_hosts`:
+
+```
+Aws::Xray.config.trace_header_excluded_hosts = ['example.com', /.*\.example\.com/]
+```
+
 #### activerecord hook
 `require 'aws/xray/hooks/active_record'`.
 

--- a/README.md
+++ b/README.md
@@ -217,11 +217,13 @@ response = Aws::Xray.overwrite(name: 'sns') do
 end
 ```
 
-If you do not want to pass trace header to other services, control with `Aws::Xray.config.trace_header_excluded_hosts`:
+If you do not want to pass trace header to other services, control with `Aws::Xray.config.trace_header_whitelist_hosts`:
 
 ```
-Aws::Xray.config.trace_header_excluded_hosts = ['example.com', /.*\.example\.com/]
+Aws::Xray.config.trace_header_whitelist_hosts = ['example.com', /.*\.example\.com/]
 ```
+
+The default is always sending trace headers.
 
 #### activerecord hook
 `require 'aws/xray/hooks/active_record'`.

--- a/lib/aws/xray/configuration.rb
+++ b/lib/aws/xray/configuration.rb
@@ -42,7 +42,7 @@ module Aws
         @sampling_rate = Float(ENV['AWS_XRAY_SAMPLING_RATE'] || 1.0)
         @solr_hook_name = 'solr'
         @record_caller_of_http_requests = false
-        @trace_header_excluded_hosts = []
+        @trace_header_whitelist_hosts = [/.*/]
       end
 
       # @param [String] name Logical service name for this application.
@@ -110,9 +110,9 @@ module Aws
       # @return [Boolean]
       attr_accessor :record_caller_of_http_requests
 
-      # @param [Array<String,Regexp>] trace_header_excluded_hosts
+      # @param [Array<String,Regexp>] trace_header_whitelist_hosts
       # @return [Array<String,Regexp>]
-      attr_accessor :trace_header_excluded_hosts
+      attr_accessor :trace_header_whitelist_hosts
     end
   end
 end

--- a/lib/aws/xray/configuration.rb
+++ b/lib/aws/xray/configuration.rb
@@ -42,6 +42,7 @@ module Aws
         @sampling_rate = Float(ENV['AWS_XRAY_SAMPLING_RATE'] || 1.0)
         @solr_hook_name = 'solr'
         @record_caller_of_http_requests = false
+        @trace_header_excluded_hosts = []
       end
 
       # @param [String] name Logical service name for this application.
@@ -108,6 +109,10 @@ module Aws
       # @param [Boolean] record_caller_of_http_requests
       # @return [Boolean]
       attr_accessor :record_caller_of_http_requests
+
+      # @param [Array<String,Regexp>] trace_header_excluded_hosts
+      # @return [Array<String,Regexp>]
+      attr_accessor :trace_header_excluded_hosts
     end
   end
 end

--- a/lib/aws/xray/hooks/net_http.rb
+++ b/lib/aws/xray/hooks/net_http.rb
@@ -41,7 +41,7 @@ module Aws
         private
 
         def pass_trace_header?(host)
-          !Aws::Xray.config.trace_header_excluded_hosts.find {|h| h === host }
+          !!Aws::Xray.config.trace_header_whitelist_hosts.find {|h| h === host }
         end
       end
     end

--- a/spec/net_http_hook_spec.rb
+++ b/spec/net_http_hook_spec.rb
@@ -152,9 +152,9 @@ RSpec.describe Aws::Xray::Hooks::NetHttp do
     client_thread.kill
   end
 
-  describe 'exclude hosts about passing trace header' do
+  describe 'whitelist hosts about passing trace header' do
     context 'when string' do
-      before { allow(Aws::Xray.config).to receive(:trace_header_excluded_hosts).and_return(['127.0.0.1']) }
+      before { allow(Aws::Xray.config).to receive(:trace_header_whitelist_hosts).and_return(['example.com']) }
 
       it 'does not pass trace header' do
         server_thread = build_server_thread
@@ -177,30 +177,7 @@ RSpec.describe Aws::Xray::Hooks::NetHttp do
     end
 
     context 'when regexp matches host' do
-      before { allow(Aws::Xray.config).to receive(:trace_header_excluded_hosts).and_return([/.*\.0\.0\.1/]) }
-
-      it 'does not pass trace header' do
-        server_thread = build_server_thread
-        client_thread = build_client_thread do
-          http = Net::HTTP.new(host, port)
-          response = http.get('/hello', { 'X-Aws-Xray-Name' => 'target-app' })
-          queue.push(response)
-        end
-
-        request_string, response, _ = queue.pop, queue.pop, queue.pop
-        expect(request_string).not_to match(/X-Amzn-Trace-Id/)
-        expect(response.code).to eq('200')
-
-        sent_jsons = io.tap(&:rewind).read.split("\n")
-        expect(sent_jsons.size).to eq(4)
-
-        server_thread.kill
-        client_thread.kill
-      end
-    end
-
-    context 'when regexp does not match host' do
-      before { allow(Aws::Xray.config).to receive(:trace_header_excluded_hosts).and_return([/.*\.1\.1\.1/]) }
+      before { allow(Aws::Xray.config).to receive(:trace_header_whitelist_hosts).and_return([/.*\.0\.0\.1/]) }
 
       it 'passes trace header' do
         server_thread = build_server_thread
@@ -212,6 +189,29 @@ RSpec.describe Aws::Xray::Hooks::NetHttp do
 
         request_string, response, _ = queue.pop, queue.pop, queue.pop
         expect(request_string).to match(/X-Amzn-Trace-Id/)
+        expect(response.code).to eq('200')
+
+        sent_jsons = io.tap(&:rewind).read.split("\n")
+        expect(sent_jsons.size).to eq(4)
+
+        server_thread.kill
+        client_thread.kill
+      end
+    end
+
+    context 'when regexp does not match host' do
+      before { allow(Aws::Xray.config).to receive(:trace_header_whitelist_hosts).and_return([/.*\.1\.1\.1/]) }
+
+      it 'does not passes trace header' do
+        server_thread = build_server_thread
+        client_thread = build_client_thread do
+          http = Net::HTTP.new(host, port)
+          response = http.get('/hello', { 'X-Aws-Xray-Name' => 'target-app' })
+          queue.push(response)
+        end
+
+        request_string, response, _ = queue.pop, queue.pop, queue.pop
+        expect(request_string).not_to match(/X-Amzn-Trace-Id/)
         expect(response.code).to eq('200')
 
         sent_jsons = io.tap(&:rewind).read.split("\n")

--- a/spec/net_http_hook_spec.rb
+++ b/spec/net_http_hook_spec.rb
@@ -151,4 +151,75 @@ RSpec.describe Aws::Xray::Hooks::NetHttp do
     server_thread.kill
     client_thread.kill
   end
+
+  describe 'exclude hosts about passing trace header' do
+    context 'when string' do
+      before { allow(Aws::Xray.config).to receive(:trace_header_excluded_hosts).and_return(['127.0.0.1']) }
+
+      it 'does not pass trace header' do
+        server_thread = build_server_thread
+        client_thread = build_client_thread do
+          http = Net::HTTP.new(host, port)
+          response = http.get('/hello', { 'X-Aws-Xray-Name' => 'target-app' })
+          queue.push(response)
+        end
+
+        request_string, response, _ = queue.pop, queue.pop, queue.pop
+        expect(request_string).not_to match(/X-Amzn-Trace-Id/)
+        expect(response.code).to eq('200')
+
+        sent_jsons = io.tap(&:rewind).read.split("\n")
+        expect(sent_jsons.size).to eq(4)
+
+        server_thread.kill
+        client_thread.kill
+      end
+    end
+
+    context 'when regexp matches host' do
+      before { allow(Aws::Xray.config).to receive(:trace_header_excluded_hosts).and_return([/.*\.0\.0\.1/]) }
+
+      it 'does not pass trace header' do
+        server_thread = build_server_thread
+        client_thread = build_client_thread do
+          http = Net::HTTP.new(host, port)
+          response = http.get('/hello', { 'X-Aws-Xray-Name' => 'target-app' })
+          queue.push(response)
+        end
+
+        request_string, response, _ = queue.pop, queue.pop, queue.pop
+        expect(request_string).not_to match(/X-Amzn-Trace-Id/)
+        expect(response.code).to eq('200')
+
+        sent_jsons = io.tap(&:rewind).read.split("\n")
+        expect(sent_jsons.size).to eq(4)
+
+        server_thread.kill
+        client_thread.kill
+      end
+    end
+
+    context 'when regexp does not match host' do
+      before { allow(Aws::Xray.config).to receive(:trace_header_excluded_hosts).and_return([/.*\.1\.1\.1/]) }
+
+      it 'passes trace header' do
+        server_thread = build_server_thread
+        client_thread = build_client_thread do
+          http = Net::HTTP.new(host, port)
+          response = http.get('/hello', { 'X-Aws-Xray-Name' => 'target-app' })
+          queue.push(response)
+        end
+
+        request_string, response, _ = queue.pop, queue.pop, queue.pop
+        expect(request_string).to match(/X-Amzn-Trace-Id/)
+        expect(response.code).to eq('200')
+
+        sent_jsons = io.tap(&:rewind).read.split("\n")
+        expect(sent_jsons.size).to eq(4)
+
+        server_thread.kill
+        client_thread.kill
+      end
+    end
+  end
 end


### PR DESCRIPTION
Down stream services may contain uncontrollable services such as third party services.
We would not like to send trace header for those services.
So I think it's useful to control passing trace header.

NOTICE: I have not confirmed this change worked on AWS X-Ray. I will notice you after confirmation.