### PR TITLE
Log strings which has an invalid byte sequence

### DIFF
--- a/lib/aws/xray/error_handlers.rb
+++ b/lib/aws/xray/error_handlers.rb
@@ -26,7 +26,11 @@ Error: #{error}
       ERROR_LEVEL = 'warning'.freeze
 
       def call(error, payload, host:, port:)
-        ::Raven.capture_exception(error, level: ERROR_LEVEL, extra: { 'payload' => payload })
+        ::Raven.capture_exception(
+          error,
+          level: ERROR_LEVEL,
+          extra: { 'payload' => payload, 'payload_raw' => payload.unpack('H*').first }
+        )
       end
     end
   end


### PR DESCRIPTION
Sometimes we have weird byte sequences for UTF-8 and it causes Aws::Xray::CanNotSendAllByteError.