### PR TITLE
Remove invalid UTF-8 byte sequence

### DIFF
--- a/lib/aws/xray/request.rb
+++ b/lib/aws/xray/request.rb
@@ -42,7 +42,7 @@ module Aws
           if str.nil?
             nil
           else
-            str.to_s.encode(__ENCODING__, invalid: :replace, undef: :replace)
+            str.to_s.encode(__ENCODING__, invalid: :replace, undef: :replace, replace: '')
           end
         end
 

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -9,9 +9,8 @@ RSpec.describe Aws::Xray::Request do
       # \x61 = a, \xe3 = illegal bytes, \x62 = b, \x63 = c
       let(:url) { "/users/\x61\xe3\x62\x63/" }
 
-      it 'serialized successfully' do
-        # \uFFFD is default unicode character in replacing illegal bytes.
-        expect(body['url']).to eq("/users/a\uFFFDbc/")
+      it 'removes them and serializes successfully' do
+        expect(body['url']).to eq("/users/abc/")
       end
     end
 


### PR DESCRIPTION
Don't replace to U+FFFD, but replace to empty string to avoid unexpected
behavior on send(2) in UDP socket.

Follow-up for https://github.com/taiki45/aws-xray/pull/23.