### PR TITLE
Convert to json in worker thread

### DIFF
--- a/lib/aws/xray/client.rb
+++ b/lib/aws/xray/client.rb
@@ -8,21 +8,16 @@ module Aws
       class << self
         # @param [Aws::Xray::Segment] segment
         def send_segment(segment)
-          Aws::Xray.config.logger.debug("#{Thread.current}: Client.send_segment started")
-          payload = %!{"format": "json", "version": 1}\n#{segment.to_json}\n!
-
           begin
             if Aws::Xray.config.client_options[:sock] # test env or not aws-xray is not enabled
-              send_payload(payload)
-              Aws::Xray.config.logger.debug("#{Thread.current}: Client.send_segment called #send_payload in the same thread")
+              send_(segment)
             else # production env
-              Worker.post(payload)
-              Aws::Xray.config.logger.debug("#{Thread.current}: Client.send_segment posted a job to worker")
+              Worker.post(segment)
             end
           rescue QueueIsFullError => e
             begin
               host, port = Aws::Xray.config.client_options[:host], Aws::Xray.config.client_options[:port]
-              Aws::Xray.config.segment_sending_error_handler.call(e, payload, host: host, port: port)
+              Aws::Xray.config.segment_sending_error_handler.call(e, '', host: host, port: port)
             rescue Exception => e
               $stderr.puts("Error handler `#{Aws::Xray.config.segment_sending_error_handler}` raised an error: #{e}\n#{e.backtrace.join("\n")}")
             end
@@ -30,16 +25,18 @@ module Aws
         end
 
         # Will be called in other threads.
-        # @param [String] payload
-        def send_payload(payload)
-          Aws::Xray.config.logger.debug("#{Thread.current}: Client#send_payload")
+        # @param [Aws::Xray::Segment] segment
+        def send_(segment)
+          Aws::Xray.config.logger.debug("#{Thread.current}: Client#send_")
+          payload = %!{"format": "json", "version": 1}\n#{segment.to_json}\n!
+
           sock = Aws::Xray.config.client_options[:sock] || UDPSocket.new
           host, port = Aws::Xray.config.client_options[:host], Aws::Xray.config.client_options[:port]
 
           begin
             len = sock.send(payload, Socket::MSG_DONTWAIT, host, port)
             raise CanNotSendAllByteError.new(payload.bytesize, len) if payload.bytesize != len
-            Aws::Xray.config.logger.debug("#{Thread.current}: Client#send_payload successfully sent payload, len=#{len}")
+            Aws::Xray.config.logger.debug("#{Thread.current}: Client#send_ successfully sent payload, len=#{len}")
             len
           rescue SystemCallError, SocketError, CanNotSendAllByteError => e
             begin


### PR DESCRIPTION
We don't need to propagate errors which are happened in converting to
json, so doing the job in worker thread to increase performance.